### PR TITLE
Vgene/issue1: Replace __malloc_hook with a library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: ["*"]
+    branches: "*"
   pull_request:
-    branches: ["*"]
+    branches: "*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: Build
 
 on:
   push:
-    branches: "*"
   pull_request:
-    branches: "*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -3,7 +3,6 @@ name: Regression Test
 on:
   workflow_run:
     workflows: ["Build"]
-    branches: "*"
     types:
       - completed
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ install: build
 	cp -r scripts/* $(INSTALL_DIR)/bin
 	@echo "export RUNTIME_LTO=$(RUNTIME_LTO)" > $(INSTALL_DIR)/PROMPT.rc
 	@echo "export SLAMP_INSTALL_DIR=$(INSTALL_DIR)" >> $(INSTALL_DIR)/PROMPT.rc
-	@echo "export PATH=$(INSTALL_DIR)/bin:\$$PATH" >> $(INSTALL_DIR)/PROMPT.rc
 	@echo "export NOELLE_LIBS_DIR=$(NOELLE_INSTALL_DIR)/lib" >> $(INSTALL_DIR)/PROMPT.rc
 	@echo "export SCAF_LIBS_DIR=$(SCAF_INSTALL_DIR)/lib" >> $(INSTALL_DIR)/PROMPT.rc
+	@echo "export PATH=$(INSTALL_DIR)/bin:\$$PATH" >> $(INSTALL_DIR)/PROMPT.rc
+	@echo "export LD_LIBRARY_PATH=$(INSTALL_DIR)/lib:\$$LD_LIBRARY_PATH" >> $(INSTALL_DIR)/PROMPT.rc
 
 
 clean:

--- a/scripts/slamp-driver
+++ b/scripts/slamp-driver
@@ -4,7 +4,7 @@
 if [ -z "$SLAMP_HOOKS" ]; then
 # if "SLAMP_INSTALL_DIR" is set
     if [ -n "$SLAMP_INSTALL_DIR" ]; then
-        SLAMP_HOOKS="$SLAMP_INSTALL_DIR/runtime/libslamp_hooks_custom.a"
+        SLAMP_HOOKS="$SLAMP_INSTALL_DIR/runtime/libslamp_hooks_custom.a -L$SLAMP_INSTALL_DIR/lib -lmalloc_hook"
     else
         echo "SLAMP_INSTALL_DIR is not set"
         exit 1

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,7 +1,10 @@
+# malloc hook
+add_subdirectory(malloc_hook)
+
 # frontend
 add_subdirectory(ProfilingModules)
-add_subdirectory(SLAMPcustom)
-add_subdirectory(SLAMPstats)
+add_subdirectory(frontend)
+# add_subdirectory(SLAMPstats)
 
 if(DO_COMPARE)
     add_subdirectory(SLAMPboost)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(malloc_hook)
 # frontend
 add_subdirectory(ProfilingModules)
 add_subdirectory(frontend)
-# add_subdirectory(SLAMPstats)
+add_subdirectory(SLAMPstats)
 
 if(DO_COMPARE)
     add_subdirectory(SLAMPboost)

--- a/src/runtime/frontend/CMakeLists.txt
+++ b/src/runtime/frontend/CMakeLists.txt
@@ -1,8 +1,6 @@
-file(
-  GLOB
-  SRCS
-  "../frontend/frontend.cpp"
-  "../frontend/slamp_ext_hooks.cpp"
+set(SRCS
+    "frontend.cpp"
+    "slamp_ext_hooks.cpp"
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -g")
@@ -20,7 +18,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Boost REQUIRED COMPONENTS system)
 include_directories(${Boost_INCLUDE_DIRS})
 
-include_directories(./)
+include_directories(./ ../)
 add_library(${PassName} STATIC ${SRCS})
 target_link_libraries(${PassName} ${Boost_LIBRARIES})
 

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -5,6 +5,10 @@
 #include <cstdio>
 #include <iostream>
 
+#include "malloc_hook/malloc_hook.h"
+
+extern "C" bool hook_enabled;
+
 //#define SAMPLING_ITER
 static int nested_level = 0;
 static bool on_profiling = false;
@@ -88,18 +92,6 @@ static void *(*old_memalign_hook)(size_t, size_t, const void *);
 #define PRODUCE_STORE(instr, addr)
 #endif
 
-#define TURN_ON_HOOKS                                                          \
-  __malloc_hook = SLAMP_malloc_hook;                                           \
-  __realloc_hook = SLAMP_realloc_hook;                                         \
-  __memalign_hook = SLAMP_memalign_hook;                                       \
-  __free_hook = SLAMP_free_hook;
-
-#define TURN_OFF_HOOKS                                                         \
-  __malloc_hook = old_malloc_hook;                                             \
-  __realloc_hook = old_realloc_hook;                                           \
-  __memalign_hook = old_memalign_hook;                                         \
-  __free_hook = old_free_hook;
-
 static volatile char *lc_dummy = NULL;
 
 PRODUCE_QUEUE_DEFINE();
@@ -125,12 +117,9 @@ void SLAMP_init(uint32_t fn_id, uint32_t loop_id) {
   // FIXME: a dirty way to get locale updated
   lc_dummy = setlocale(LC_ALL, "");
 
-  old_malloc_hook = __malloc_hook;
-  old_free_hook = __free_hook;
-  old_memalign_hook = __memalign_hook;
-  old_realloc_hook = __realloc_hook;
+  // TURN ON HOOKS
+  hook_enabled = true;
 
-  TURN_ON_HOOKS;
   // flush
   PRODUCE_QUEUE_FLUSH_AND_WAIT();
 }
@@ -139,6 +128,9 @@ void SLAMP_fini(const char *filename) {
   PRODUCE_FINISHED();
 
   PRODUCE_QUEUE_FLUSH();
+
+  // TURN OFF HOOKS
+  hook_enabled = false;
 
   if (nested_level != 0) {
     std::cerr << "Error: nested_level != 0 on exit" << std::endl;
@@ -302,37 +294,18 @@ void SLAMP_storen_ext(const uint64_t addr, const uint32_t bare_inst, size_t n) {
   SLAMP_storen(bare_inst, addr, n);
 }
 
-/* wrappers for memory allocation events*/
-static void *SLAMP_malloc_hook(size_t size, const void *caller) {
-  TURN_OFF_HOOKS
-  void *ptr = malloc(size);
+
+void malloc_callback(void* ptr, size_t size) {
   PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)ptr);
-  TURN_ON_HOOKS
-  return ptr;
 }
-
-static void *SLAMP_realloc_hook(void *ptr, size_t size, const void *caller) {
-  TURN_OFF_HOOKS
-  void *new_ptr = realloc(ptr, size);
-  PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)new_ptr);
-  TURN_ON_HOOKS
-  return new_ptr;
-}
-
-static void *SLAMP_memalign_hook(size_t alignment, size_t size,
-                                 const void *caller) {
-  TURN_OFF_HOOKS
-  void *ptr = memalign(alignment, size);
-  PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)ptr);
-  TURN_ON_HOOKS
-  return ptr;
-}
-
-static void SLAMP_free_hook(void *ptr, const void *caller) {
-  TURN_OFF_HOOKS
-  free(ptr);
+void free_callback(void* ptr) {
   PRODUCE_FREE((uint64_t)ptr);
-  TURN_ON_HOOKS
+}
+void realloc_callback(void* new_ptr, void* ptr, size_t size) {
+  PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)new_ptr);
+}
+void memalign_callback(void* ptr, size_t alignment, size_t size) {
+  PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)ptr);
 }
 
 // FIXME: a bunch of unused functions

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -9,7 +9,7 @@
 
 extern "C" bool hook_enabled;
 
-//#define SAMPLING_ITER
+// #define SAMPLING_ITER
 static int nested_level = 0;
 static bool on_profiling = false;
 
@@ -294,17 +294,14 @@ void SLAMP_storen_ext(const uint64_t addr, const uint32_t bare_inst, size_t n) {
   SLAMP_storen(bare_inst, addr, n);
 }
 
-
-void malloc_callback(void* ptr, size_t size) {
+void malloc_callback(void *ptr, size_t size) {
   PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)ptr);
 }
-void free_callback(void* ptr) {
-  PRODUCE_FREE((uint64_t)ptr);
-}
-void realloc_callback(void* new_ptr, void* ptr, size_t size) {
+void free_callback(void *ptr) { PRODUCE_FREE((uint64_t)ptr); }
+void realloc_callback(void *new_ptr, void *ptr, size_t size) {
   PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)new_ptr);
 }
-void memalign_callback(void* ptr, size_t alignment, size_t size) {
+void memalign_callback(void *ptr, size_t alignment, size_t size) {
   PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)ptr);
 }
 

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -1,4 +1,3 @@
-#include "malloc.h"
 #include "slamp_hooks.h"
 #include "slamp_produce.h"
 #include <cstdint>

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -298,6 +298,8 @@ void malloc_callback(void *ptr, size_t size) {
 }
 void free_callback(void *ptr) { PRODUCE_FREE((uint64_t)ptr); }
 void realloc_callback(void *new_ptr, void *ptr, size_t size) {
+  // TODO: the old pointer might be freed. Need to check whether the two
+  // pointers are the same
   PRODUCE_ALLOC(ext_fn_inst_id, size, (uint64_t)new_ptr);
 }
 void memalign_callback(void *ptr, size_t alignment, size_t size) {

--- a/src/runtime/malloc_hook/CMakeLists.txt
+++ b/src/runtime/malloc_hook/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Define the library target
+add_library(malloc_hook SHARED malloc_hook.c)
+
+# Set the library properties
+target_include_directories(malloc_hook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Install the library
+install(TARGETS malloc_hook
+    LIBRARY DESTINATION lib
+    PUBLIC_HEADER DESTINATION include
+)

--- a/src/runtime/malloc_hook/CMakeLists.txt
+++ b/src/runtime/malloc_hook/CMakeLists.txt
@@ -5,7 +5,4 @@ add_library(malloc_hook SHARED malloc_hook.c)
 target_include_directories(malloc_hook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Install the library
-install(TARGETS malloc_hook
-    LIBRARY DESTINATION lib
-    PUBLIC_HEADER DESTINATION include
-)
+install(TARGETS malloc_hook LIBRARY DESTINATION lib)

--- a/src/runtime/malloc_hook/malloc_hook.c
+++ b/src/runtime/malloc_hook/malloc_hook.c
@@ -1,0 +1,49 @@
+#include <stdbool.h>
+#include "malloc_hook.h"
+
+bool hook_enabled = false;
+
+extern void* __libc_malloc(size_t size);
+extern void __libc_free(void* ptr);
+extern void* __libc_realloc(void* ptr, size_t size);
+extern void* __libc_memalign(size_t alignment, size_t size);
+
+void __attribute__((weak)) malloc_callback(void* ptr, size_t size) {}
+
+void __attribute__((weak)) free_callback(void* ptr) {}
+
+
+void __attribute__((weak)) realloc_callback(void* new_ptr, void* ptr, size_t size) {}
+
+void __attribute__((weak)) memalign_callback(void* ptr, size_t alignment, size_t size) {}
+
+void* malloc(size_t size) {
+    void* ptr =  __libc_malloc(size);
+    if (hook_enabled) {
+        malloc_callback(ptr, size);
+    }
+    return ptr;
+}
+
+void free(void* ptr) {
+    __libc_free(ptr);
+    if (hook_enabled) {
+        free_callback(ptr);
+    }
+}
+
+void* realloc(void* ptr, size_t size) {
+    void* new_ptr = __libc_realloc(ptr, size);
+    if (hook_enabled) {
+        realloc_callback(new_ptr, ptr, size);
+    }
+    return new_ptr;
+}
+
+void* memalign(size_t alignment, size_t size) {
+    void* ptr = __libc_memalign(alignment, size);
+    if (hook_enabled) {
+        memalign_callback(ptr, alignment, size);
+    }
+    return ptr;
+}

--- a/src/runtime/malloc_hook/malloc_hook.c
+++ b/src/runtime/malloc_hook/malloc_hook.c
@@ -1,49 +1,50 @@
-#include <stdbool.h>
 #include "malloc_hook.h"
+#include <stdbool.h>
 
 bool hook_enabled = false;
 
-extern void* __libc_malloc(size_t size);
-extern void __libc_free(void* ptr);
-extern void* __libc_realloc(void* ptr, size_t size);
-extern void* __libc_memalign(size_t alignment, size_t size);
+extern void *__libc_malloc(size_t size);
+extern void __libc_free(void *ptr);
+extern void *__libc_realloc(void *ptr, size_t size);
+extern void *__libc_memalign(size_t alignment, size_t size);
 
-void __attribute__((weak)) malloc_callback(void* ptr, size_t size) {}
+void __attribute__((weak)) malloc_callback(void *ptr, size_t size) {}
 
-void __attribute__((weak)) free_callback(void* ptr) {}
+void __attribute__((weak)) free_callback(void *ptr) {}
 
+void __attribute__((weak))
+realloc_callback(void *new_ptr, void *ptr, size_t size) {}
 
-void __attribute__((weak)) realloc_callback(void* new_ptr, void* ptr, size_t size) {}
+void __attribute__((weak))
+memalign_callback(void *ptr, size_t alignment, size_t size) {}
 
-void __attribute__((weak)) memalign_callback(void* ptr, size_t alignment, size_t size) {}
-
-void* malloc(size_t size) {
-    void* ptr =  __libc_malloc(size);
-    if (hook_enabled) {
-        malloc_callback(ptr, size);
-    }
-    return ptr;
+void *malloc(size_t size) {
+  void *ptr = __libc_malloc(size);
+  if (hook_enabled) {
+    malloc_callback(ptr, size);
+  }
+  return ptr;
 }
 
-void free(void* ptr) {
-    __libc_free(ptr);
-    if (hook_enabled) {
-        free_callback(ptr);
-    }
+void free(void *ptr) {
+  __libc_free(ptr);
+  if (hook_enabled) {
+    free_callback(ptr);
+  }
 }
 
-void* realloc(void* ptr, size_t size) {
-    void* new_ptr = __libc_realloc(ptr, size);
-    if (hook_enabled) {
-        realloc_callback(new_ptr, ptr, size);
-    }
-    return new_ptr;
+void *realloc(void *ptr, size_t size) {
+  void *new_ptr = __libc_realloc(ptr, size);
+  if (hook_enabled) {
+    realloc_callback(new_ptr, ptr, size);
+  }
+  return new_ptr;
 }
 
-void* memalign(size_t alignment, size_t size) {
-    void* ptr = __libc_memalign(alignment, size);
-    if (hook_enabled) {
-        memalign_callback(ptr, alignment, size);
-    }
-    return ptr;
+void *memalign(size_t alignment, size_t size) {
+  void *ptr = __libc_memalign(alignment, size);
+  if (hook_enabled) {
+    memalign_callback(ptr, alignment, size);
+  }
+  return ptr;
 }

--- a/src/runtime/malloc_hook/malloc_hook.h
+++ b/src/runtime/malloc_hook/malloc_hook.h
@@ -3,9 +3,16 @@
 
 #include <stddef.h>
 
-void malloc_callback(void* ptr, size_t size);
-void free_callback(void* ptr);
-void realloc_callback(void* new_ptr, void* ptr, size_t size);
-void memalign_callback(void* ptr, size_t alignment, size_t size);
+#ifdef __cplusplus
+extern "C" {
+#endif
+void malloc_callback(void *ptr, size_t size);
+void free_callback(void *ptr);
+void realloc_callback(void *new_ptr, void *ptr, size_t size);
+void memalign_callback(void *ptr, size_t alignment, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MALLOC_HOOK_H */

--- a/src/runtime/malloc_hook/malloc_hook.h
+++ b/src/runtime/malloc_hook/malloc_hook.h
@@ -1,0 +1,11 @@
+#ifndef MALLOC_HOOK_H
+#define MALLOC_HOOK_H
+
+#include <stddef.h>
+
+void malloc_callback(void* ptr, size_t size);
+void free_callback(void* ptr);
+void realloc_callback(void* new_ptr, void* ptr, size_t size);
+void memalign_callback(void* ptr, size_t alignment, size_t size);
+
+#endif /* MALLOC_HOOK_H */


### PR DESCRIPTION
Replace __malloc_hook with a custom malloc_hook library, that get loaded with the profiled program and replace the weak malloc related symbols and expose a call back function

Fixed #1 